### PR TITLE
Proofs saving

### DIFF
--- a/Data Fetch (ZKTLS)/tls-notary/browser-extension/css/styles.css
+++ b/Data Fetch (ZKTLS)/tls-notary/browser-extension/css/styles.css
@@ -121,6 +121,28 @@ button:hover {
 .status-verified { background-color: #188038; }
 .status-failed { background-color: #d93025; }
 
+.delete-proof-btn {
+  background-color: #d93025;
+  color: white;
+  border: none;
+  padding: 2px 4px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  margin-left: 10px;
+  float: right;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.delete-proof-btn:hover {
+  background-color: #b7271e;
+}
+
 .modal {
   display: none;
   position: fixed;

--- a/Data Fetch (ZKTLS)/tls-notary/browser-extension/src/services/BrowserTLSNotaryService.ts
+++ b/Data Fetch (ZKTLS)/tls-notary/browser-extension/src/services/BrowserTLSNotaryService.ts
@@ -1,0 +1,222 @@
+import { ProofRecord, RequestStatus, VerifyProofResult, TLSFormData, TLSNotaryService } from 'tls-notary-shared';
+import { getProofs, setProofs } from '../utils/storageUtils';
+import { TLSProof } from '../types/types';
+
+/**
+ * Convert a ProofRecord to a TLSProof for storage
+ */
+function proofRecordToTLSProof(record: ProofRecord): TLSProof {
+  return {
+    url: record.formData.url,
+    method: record.formData.method,
+    headers: record.tlsCall?.request.headers || {},
+    body: record.formData.body || null,
+    timestamp: record.timestamp || new Date().toISOString(),
+    status: record.status,
+    proofData: {
+      id: record.id,
+      formData: record.formData,
+      tunnelReq: record.tunnelReq,
+      tunnelRes: record.tunnelRes,
+      tlsCall: record.tlsCall,
+      tlsCallResponse: record.tlsCallResponse,
+      verifyProofResult: record.verifyProofResult,
+      error: record.error
+    }
+  };
+}
+
+/**
+ * Convert a TLSProof to a ProofRecord for use in the application
+ */
+function tlsProofToProofRecord(proof: TLSProof): ProofRecord {
+  if (!proof.proofData) {
+    throw new Error('TLSProof does not contain proofData');
+  }
+
+  return {
+    id: proof.proofData.id,
+    status: proof.status as RequestStatus,
+    error: proof.proofData.error,
+    timestamp: proof.timestamp,
+    formData: proof.proofData.formData,
+    tunnelReq: proof.proofData.tunnelReq,
+    tunnelRes: proof.proofData.tunnelRes,
+    tlsCall: proof.proofData.tlsCall,
+    tlsCallResponse: proof.proofData.tlsCallResponse,
+    verifyProofResult: proof.proofData.verifyProofResult
+  };
+}
+
+/**
+ * Browser-specific implementation of TLSNotaryService that uses browser storage
+ */
+class BrowserTLSNotaryService {
+  private static instance: BrowserTLSNotaryService;
+  private records: ProofRecord[] = [];
+  private subscribers: ((records: ProofRecord[]) => void)[] = [];
+  private initializationPromise: Promise<void> | null = null;
+
+  private constructor() {
+    // Initialize the service
+    this.initialize();
+  }
+
+  /**
+   * Initialize the service by loading proofs from storage
+   * This method is called automatically by the constructor
+   * @returns Promise that resolves when initialization is complete
+   */
+  private initialize(): Promise<void> {
+    if (!this.initializationPromise) {
+      console.log('Initializing BrowserTLSNotaryService');
+      this.initializationPromise = this.loadProofsFromStorage().catch(error => {
+        console.error('Error initializing BrowserTLSNotaryService:', error);
+        // Reset the initialization promise so it can be retried
+        this.initializationPromise = null;
+        // Re-throw the error to propagate it to callers
+        throw error;
+      });
+    }
+    return this.initializationPromise;
+  }
+
+  /**
+   * Get the singleton instance of BrowserTLSNotaryService
+   */
+  public static getInstance(): BrowserTLSNotaryService {
+    if (!BrowserTLSNotaryService.instance) {
+      BrowserTLSNotaryService.instance = new BrowserTLSNotaryService();
+    }
+    return BrowserTLSNotaryService.instance;
+  }
+
+  /**
+   * Load proofs from storage
+   */
+  private async loadProofsFromStorage() {
+    try {
+      console.log('Loading proofs from browser storage');
+      const storedProofs = await getProofs();
+      if (storedProofs && storedProofs.length > 0) {
+        // Convert TLSProof objects to ProofRecord objects
+        this.records = storedProofs.map(tlsProofToProofRecord);
+        console.log(`Loaded ${storedProofs.length} proofs from browser storage`);
+        this.notifySubscribers();
+      } else {
+        console.log('No proofs found in browser storage');
+      }
+    } catch (error) {
+      console.error('Error loading proofs from browser storage:', error);
+    }
+  }
+
+  /**
+   * Save proofs to storage
+   */
+  private async saveProofsToStorage() {
+    try {
+      // Filter records to only include those that have been received
+      const receivedRecords = this.records.filter(record => 
+        record.status === RequestStatus.Received || 
+        record.status === RequestStatus.Pending || 
+        record.status === RequestStatus.Verified
+      );
+
+      console.log(`Saving ${receivedRecords.length} received proofs to browser storage (out of ${this.records.length} total)`);
+
+      // Convert ProofRecord objects to TLSProof objects
+      const tlsProofs = receivedRecords.map(proofRecordToTLSProof);
+      await setProofs(tlsProofs);
+    } catch (error) {
+      console.error('Error saving proofs to browser storage:', error);
+    }
+  }
+
+  private notifySubscribers() {
+    console.log(`Notifying ${this.subscribers.length} subscribers of record changes`);
+    const snapshot = [...this.records];
+    this.subscribers.forEach((cb) => cb(snapshot));
+    console.log('All subscribers notified');
+
+    // Save proofs to storage whenever they change
+    this.saveProofsToStorage();
+  }
+
+  async subscribe(callback: (records: ProofRecord[]) => void): Promise<() => void> {
+    console.log('New subscriber added to BrowserTLSNotaryService');
+
+    // Ensure the service is initialized before proceeding
+    await this.initialize();
+
+    this.subscribers.push(callback);
+    console.log('Sending initial records to new subscriber');
+    callback([...this.records]);
+    return () => {
+      console.log('Unsubscribing from BrowserTLSNotaryService');
+      this.subscribers = this.subscribers.filter((cb) => cb !== callback);
+      console.log(`Remaining subscribers: ${this.subscribers.length}`);
+    };
+  }
+
+  async getAllProofs(): Promise<ProofRecord[]> {
+    console.log('BrowserTLSNotaryService.getAllProofs called');
+
+    // Ensure the service is initialized before proceeding
+    await this.initialize();
+
+    const records = [...this.records];
+    console.log(`Returning ${records.length} proof records`);
+    return records;
+  }
+
+  // Method to add a proof record (used by the shared module's service)
+  async addProofRecord(record: ProofRecord): Promise<void> {
+    console.log('BrowserTLSNotaryService.addProofRecord called with record:', record);
+
+    // Ensure the service is initialized before proceeding
+    await this.initialize();
+
+    const existingIndex = this.records.findIndex((r) => r.id === record.id);
+    if (existingIndex >= 0) {
+      console.log('Updating existing proof record');
+      this.records[existingIndex] = record;
+    } else {
+      console.log('Adding new proof record');
+      this.records.unshift(record);
+    }
+    this.notifySubscribers();
+  }
+
+  /**
+   * Delete a proof record by ID
+   * @param id The ID of the proof to delete
+   * @returns Promise that resolves when the proof is deleted
+   */
+  async deleteProof(id: string): Promise<void> {
+    console.log(`BrowserTLSNotaryService.deleteProof called with ID: ${id}`);
+
+    // Ensure the service is initialized before proceeding
+    await this.initialize();
+
+    const existingIndex = this.records.findIndex((r) => r.id === id);
+    if (existingIndex >= 0) {
+      console.log('Deleting proof record from BrowserTLSNotaryService');
+      this.records.splice(existingIndex, 1);
+      this.notifySubscribers();
+
+      // Also delete the proof from the shared module's TLSNotaryService
+      try {
+        console.log('Deleting proof record from shared module TLSNotaryService');
+        await TLSNotaryService.deleteProof(id);
+      } catch (error) {
+        console.error('Error deleting proof from shared module:', error);
+      }
+    } else {
+      console.log(`Proof with ID ${id} not found`);
+    }
+  }
+}
+
+// Export the singleton instance
+export const browserTLSNotaryService = BrowserTLSNotaryService.getInstance();

--- a/Data Fetch (ZKTLS)/tls-notary/browser-extension/src/services/TLSNotaryServiceBridge.ts
+++ b/Data Fetch (ZKTLS)/tls-notary/browser-extension/src/services/TLSNotaryServiceBridge.ts
@@ -1,0 +1,72 @@
+import { ProofRecord, TLSNotaryService } from 'tls-notary-shared';
+import { browserTLSNotaryService } from './BrowserTLSNotaryService';
+
+/**
+ * Bridge between the shared module's TLSNotaryService and the browser-extension's BrowserTLSNotaryService
+ * This ensures that proofs created by the shared module are also saved in the browser-extension's storage
+ */
+export class TLSNotaryServiceBridge {
+  private static instance: TLSNotaryServiceBridge;
+  private unsubscribe: (() => void) | null = null;
+
+  private constructor() {
+    // Call initialize without awaiting it
+    // This is necessary because constructors can't be async
+    this.initialize().catch(error => {
+      console.error('Error initializing TLSNotaryServiceBridge:', error);
+    });
+  }
+
+  /**
+   * Get the singleton instance of TLSNotaryServiceBridge
+   */
+  public static getInstance(): TLSNotaryServiceBridge {
+    if (!TLSNotaryServiceBridge.instance) {
+      TLSNotaryServiceBridge.instance = new TLSNotaryServiceBridge();
+    }
+    return TLSNotaryServiceBridge.instance;
+  }
+
+  /**
+   * Initialize the bridge by subscribing to the shared module's TLSNotaryService
+   */
+  private async initialize(): Promise<void> {
+    console.log('Initializing TLSNotaryServiceBridge');
+
+    // Get all proofs from the browser-extension's BrowserTLSNotaryService
+    const proofs = await browserTLSNotaryService.getAllProofs();
+    console.log(`Retrieved ${proofs.length} proofs from BrowserTLSNotaryService`);
+
+    // Initialize the shared module's TLSNotaryService with these proofs
+    if (proofs.length > 0) {
+      console.log('Initializing TLSNotaryService with proofs from BrowserTLSNotaryService');
+      // Cast TLSNotaryService to any to access the initializeProofs method
+      // which is not part of the ITLSNotaryService interface
+      (TLSNotaryService as any).initializeProofs(proofs);
+    }
+
+    // Subscribe to the shared module's TLSNotaryService to get updates when proofs change
+    this.unsubscribe = TLSNotaryService.subscribe((records: ProofRecord[]) => {
+      console.log(`Received ${records.length} records from TLSNotaryService`);
+
+      // For each record, add it to the browser-extension's BrowserTLSNotaryService
+      records.forEach(async (record) => {
+        await browserTLSNotaryService.addProofRecord(record);
+      });
+    });
+  }
+
+  /**
+   * Clean up the bridge by unsubscribing from the shared module's TLSNotaryService
+   */
+  public dispose(): void {
+    console.log('Disposing TLSNotaryServiceBridge');
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
+    }
+  }
+}
+
+// Export the singleton instance
+export const tlsNotaryServiceBridge = TLSNotaryServiceBridge.getInstance();

--- a/Data Fetch (ZKTLS)/tls-notary/server/README.md
+++ b/Data Fetch (ZKTLS)/tls-notary/server/README.md
@@ -1,0 +1,47 @@
+# TLS Notary Local Proxy Server
+
+A WebSocket-based proxy server for TLS Notary.
+
+## Docker Image
+
+The server is available as a Docker image for easy deployment.
+
+### Building the Docker Image
+
+To build the Docker image locally:
+
+```bash
+docker build -t tls-notary-proxy .
+```
+
+### Running the Docker Container
+
+To run the container:
+
+```bash
+docker run -p 8090:8090 -p 8091:8091 tls-notary-proxy
+```
+
+This will start the proxy server and expose it on port 8080 on your host machine.
+
+### Environment Variables
+
+The following environment variables can be configured:
+
+| Variable | Description                          | Default         |
+|----------|--------------------------------------|-----------------|
+| PORT | The port on which the server listens | 8090            |
+| SOCKET_PORT | The port on which sockets created    | 8091            |
+| CORS_ORIGIN | CORS origin setting                  | * (all origins) |
+| WEB_SOCKET_HOST | WebSocket host                       | localhost       |
+
+Example with custom configuration:
+
+```bash
+docker run -p 9000:9000 -p 9001:9001 \
+  -e PORT=9000 \
+  -e SOCKET_PORT=9001 \
+  -e CORS_ORIGIN=https://example.com \
+  -e WEB_SOCKET_HOST=proxy.example.com \
+  tls-notary-proxy
+```

--- a/Data Fetch (ZKTLS)/tls-notary/shared/src/script/generateProofs.ts
+++ b/Data Fetch (ZKTLS)/tls-notary/shared/src/script/generateProofs.ts
@@ -104,18 +104,7 @@ export async function generateProof(
         notaryUrl: call.notaryUrl
     });
 
-    if (!wasmInitialized) {
-        try {
-            await init({
-                loggingLevel: loggingLevel,
-                // wasmURL: '/build/tlsn_wasm_bg.wasm',
-            });
-            wasmInitialized = true;
-        } catch (error) {
-            console.error('Error initializing WASM:', error);
-            throw new Error('Failed to initialize WASM. Please check if the WASM file exists at the specified path.');
-        }
-    }
+    await initWasm();
 
     console.log('Creating notary server from URL:', call.notaryUrl);
     const notary = NotaryServer.from(call.notaryUrl);
@@ -248,7 +237,9 @@ export async function generateProof(
 export async function verifyProof(notaryUrl: string, presentationJSON: PresentationJSON): Promise<VerifyProofResult> {
     console.log('Starting verifyProof function with notaryUrl:', notaryUrl);
 
-    console.log('Creating presentation object from JSON data');
+    await initWasm();
+
+    console.log('Creating presentation object from JSON data:', presentationJSON.data);
     const proof = (await new Presentation(
         presentationJSON.data,
     )) as TPresentation;
@@ -305,4 +296,20 @@ function flattenObjectToStrings(obj: Record<string, any>, separator: string = '.
 
     console.log(`flattenObjectToStrings returning ${result.length} entries`);
     return result;
+}
+
+
+async function initWasm() {
+    if (!wasmInitialized) {
+        try {
+            await init({
+                loggingLevel: loggingLevel,
+                // wasmURL: '/build/tlsn_wasm_bg.wasm',
+            });
+            wasmInitialized = true;
+        } catch (error) {
+            console.error('Error initializing WASM:', error);
+            throw new Error('Failed to initialize WASM. Please check if the WASM file exists at the specified path.');
+        }
+    }
 }

--- a/Data Fetch (ZKTLS)/tls-notary/shared/src/services/ITLSNotaryService.ts
+++ b/Data Fetch (ZKTLS)/tls-notary/shared/src/services/ITLSNotaryService.ts
@@ -6,4 +6,5 @@ export interface ITLSNotaryService {
   getProof(id: string): Promise<ProofRecord | null>; // returns a single proof by ID
   subscribe(callback: (records: ProofRecord[]) => void): () => void; // listener for changes
   verifyProof(record : ProofRecord): Promise<VerifyProofResult>
+  deleteProof(id: string): Promise<void>;           // deletes a proof by ID
 }

--- a/Data Fetch (ZKTLS)/tls-notary/shared/src/services/MockTLSNotaryService.ts
+++ b/Data Fetch (ZKTLS)/tls-notary/shared/src/services/MockTLSNotaryService.ts
@@ -20,6 +20,38 @@ export class MockTLSNotaryService implements ITLSNotaryService {
   private records: ProofRecord[] = [];
   private subscribers: ((records: ProofRecord[]) => void)[] = [];
 
+  private async cleanupExistingTunnel(tunnelReq: { localPort: number, remoteHost: string, remotePort: number }): Promise<void> {
+    console.log('Cleaning up existing tunnel with parameters:', tunnelReq);
+
+    try {
+      // Get all tunnels from the server
+      const tunnels = await tunnelService.getAll();
+      console.log(`Found ${tunnels.length} tunnels on the server`);
+
+      // Find tunnels with matching parameters
+      const matchingTunnels = tunnels.filter(tunnel => 
+        tunnel.localPort === tunnelReq.localPort &&
+        tunnel.remoteHost === tunnelReq.remoteHost &&
+        tunnel.remotePort === tunnelReq.remotePort
+      );
+
+      if (matchingTunnels.length > 0) {
+        console.log(`Found ${matchingTunnels.length} matching tunnels to clean up`);
+
+        // Delete each matching tunnel
+        for (const tunnel of matchingTunnels) {
+          console.log(`Deleting tunnel with ID: ${tunnel.id}`);
+          await tunnelService.delete(tunnel.id);
+          console.log(`Successfully deleted tunnel with ID: ${tunnel.id}`);
+        }
+      } else {
+        console.log('No matching tunnels found to clean up');
+      }
+    } catch (error) {
+      console.error('Error cleaning up existing tunnels:', error);
+    }
+  }
+
   /**
    * Initialize proofs from an external source
    * @param proofs Array of ProofRecord objects to initialize with
@@ -191,13 +223,35 @@ export class MockTLSNotaryService implements ITLSNotaryService {
           console.warn('Record not found after error for ID:', id);
         }
       });
-    }).catch((error) => {
+    }).catch(async (error) => {
       console.error("Error creating tunnel:", error);
       const record = this.records.find((r) => r.id === id);
       if (record) {
         console.log('Updating record with error status');
         record.status = RequestStatus.Error;
         record.error = error;
+
+        // Check if the error is about a tunnel already existing
+        if (error && error.error && typeof error.error === 'string' && 
+            error.error.includes('Tunnel with these parameters already exists')) {
+          console.log('Detected "Tunnel already exists" error, attempting to clean up existing tunnel');
+
+          try {
+            // Clean up the existing tunnel with the same parameters
+            await this.cleanupExistingTunnel(record.tunnelReq);
+
+            // Retry the request after a short delay
+            console.log('Retrying the request after cleaning up existing tunnel');
+            setTimeout(() => {
+              this.sendRequest(input).catch(retryError => {
+                console.error('Error retrying request after tunnel cleanup:', retryError);
+              });
+            }, 1000); // Wait 1 second before retrying
+          } catch (cleanupError) {
+            console.error('Error during tunnel cleanup:', cleanupError);
+          }
+        }
+
         this.notifySubscribers();
       } else {
         console.warn('Record not found after tunnel error for ID:', id);

--- a/Data Fetch (ZKTLS)/tls-notary/shared/src/types/dto.ts
+++ b/Data Fetch (ZKTLS)/tls-notary/shared/src/types/dto.ts
@@ -5,7 +5,7 @@ export interface TunnelCreateRequest {
 }
 
 export interface TunnelCreateResponse {
-  id?: number;
+  id: number;
   localPort: number;
   remoteHost: string;
   remotePort: number;


### PR DESCRIPTION
Save proofs between restarts
Only proofs in states Received, Pending and Verified are saved
Add button to delete unneeded proofs
Some fixes to be able to verify proofs after extension restart
Fixes for hanged tunnels after closing extension in the middle of request. Now, if we get error about already created tunnel, this tunnel is deleted and request is retried 